### PR TITLE
Remove semi colon from Hanoi define block

### DIFF
--- a/content/tla/tuples/tla/hanoi.tla
+++ b/content/tla/tuples/tla/hanoi.tla
@@ -5,7 +5,7 @@ EXTENDS TLC, Sequences, Integers
 variables tower = <<<<1, 2, 3>>, <<>>, <<>>>>, 
 
 define 
-  D == DOMAIN tower;
+  D == DOMAIN tower
 end define;
 
 begin


### PR DESCRIPTION
This semi colon is not needed and breaks translation.