### PR TITLE
Corrected typos in expressions

### DIFF
--- a/content/tla/expressions.md
+++ b/content/tla/expressions.md
@@ -16,7 +16,7 @@ We've used these for a while now: `/\` is and, `\/` is or. We can join expressio
 
 /\ TRUE
   \/ TRUE
-  \/ FALSE \* (T /\ (T \/ F))
+  \/ FALSE \* (T \/ T \/ F)
 
 \/ TRUE
 \/ TRUE

--- a/content/tla/functions.md
+++ b/content/tla/functions.md
@@ -76,7 +76,7 @@ We would call pref with `pref[<<p, a>>]`. I've personally found this to be the l
 {{%/q %}}
 
 {{% q %}}
-`EXTENDS Sequence` gives you the `Seq(S)` operator, which gives you the set of all sequences with a range in S. Unfortunately, you can't actually use this operator, since it will crash TLC. So let's make some better versions. First, write an operator that returns a tuple of N copies of a set. For example `Op(S, 3) == S \X S \X S`.
+`EXTENDS Sequences` gives you the `Seq(S)` operator, which gives you the set of all sequences with a range in S. Unfortunately, you can't actually use this operator, since it will crash TLC. So let's make some better versions. First, write an operator that returns a tuple of N copies of a set. For example `Op(S, 3) == S \X S \X S`.
 
 {{% ans tup %}}
 `Tup(S, n) == [1..n -> S]`

--- a/content/tla/operators.md
+++ b/content/tla/operators.md
@@ -58,7 +58,7 @@ RECURSIVE SetReduce(_, _, _)
 
 SetReduce(Op(_, _), S, value) == IF S = {} THEN value
                               ELSE LET s == CHOOSE s \in S: TRUE
-                              IN SetReduce(Op, S \ {s}, Op(s, value)) 
+                                   IN SetReduce(Op, S \ {s}, Op(s, value)) 
 
 CandlesOnChannukah == SetReduce(Sum, 2..9, 0) \* 44
 ```


### PR DESCRIPTION
Here, in Logical Junctions, the second example is equivalent to  : (T \\/ T \\/ F)  , instead of what is written  : T /\ (T \\/ F)
