### PR TITLE
Simple fix to Tuples & Structures section

### DIFF
--- a/content/tla/tuples/_index.md
+++ b/content/tla/tuples/_index.md
@@ -67,7 +67,7 @@ The first is a tuple of length three, the latter two are tuples of length two, o
 
 ### Structures
 
-Structures are hashes. They have keys and values. You specify them as `[key |-> value]` and query them with either `[key]` or `.key`. Both are legal and valid.
+Structures are hashes. They have keys and values. You specify them as `[key |-> value]` and query them with either `["key"]` or `.key`. Both are legal and valid.
 
 ```
 x = [a |-> 1, b |-> {2, 3}];


### PR DESCRIPTION
struct[key] isn't valid, whereas struct["key"] is, apparently -- the subsequent example shows this but this particular line tripped me up.