### PR TITLE
Fix `Counter(str)` example in tla/functions.md

### DIFF
--- a/content/tla/functions.md
+++ b/content/tla/functions.md
@@ -26,7 +26,7 @@ Similarly, you can write `DOMAIN F` to get the set of values F is defined on, an
 Write an operator that takes a string (tuple of characters, here) and returns the number of occurrences of each string token.
 {{< ans counter >}}
 ```tla
-Counter(str) == [c \in Range(str) |-> Cardinality(n \in 1..Len(str) : str[n] = c)]
+Counter(str) == [c \in Range(str) |-> Cardinality({n \in 1..Len(str) : str[n] = c})]
 ```
 {{< /ans >}}
 {{%/q %}}


### PR DESCRIPTION
TLA+ Toolbox couldn't parse that example, I had to wrap what's inside `Cardinality` into curly braces.