### PR TITLE
Suggestion: Add quotes around "and" and "or" when explaining logical operator notation.

### DIFF
--- a/content/tla/expressions.md
+++ b/content/tla/expressions.md
@@ -7,7 +7,7 @@ We've been implicitly using _expressions_ up until now; we just haven't clarifie
 
 ### Logical Junctions
 
-We've used these for a while now: `/\` is and, `\/` is or. We can join expressions with them. The one subtlety is that this is the _only_ case where TLA+ is whitespace sensitive. If you start a line with an indented junction, TLA+ considers that the start of a subclause. For example,
+We've used these for a while now: `/\` is "and", `\/` is "or". We can join expressions with them. The one subtlety is that this is the _only_ case where TLA+ is whitespace sensitive. If you start a line with an indented junction, TLA+ considers that the start of a subclause. For example,
 
 ```tla
 /\ TRUE


### PR DESCRIPTION
Hi @hwayne!  I was reading learntla.com after the PyCon open space yesterday and thought this sentence might be a bit clearer with quotes around the words "and" and "or". Feel free to close and/or modify this if you disagree.