### PR TITLE
Add note describing "unknown operator" error

### DIFF
--- a/content/introduction/example/_index.md
+++ b/content/introduction/example/_index.md
@@ -82,6 +82,10 @@ A few things should leap out here. First, this isn't part of the PlusCal algorit
 
 How is this different from `assert`? Assert checks in one place. We can specify MoneyNotNegative as an _Invariant_ of the system, something that must be true in all possible system states. It becomes part of the model, and then it'll check before money is pulled from Alice's account, being the deposit and the withdrawal, etc. If we added a `money := money - 2` step anywhere the MoneyNotNegative invariant will catch that the spec fails when `money = 1`.
 
+{{% notice note %}}
+*If the model complains that MoneyInvariant is an unknown operator, you may have put the definition after the close of the module. Remember, everything after the first line beginning with `====` is ignored!*
+{{% /notice %}}
+
 ### One step further: checking Atomicity
 
 So far we haven't done anything too out of the ordinary. Everything so far is easily coverable in a real system by unit and property tests. There's still a lot more ground to cover, but I want to show that we can already use what we've learned to find more complicated bugs. Alice wants to give Bob 1,000 dollars. If we're unlucky, it could play out like this:


### PR DESCRIPTION
Reiterate that the module that TLA+ "sees" is closed by `====`.

When I copied the algorithm example into my TLA+ editor, I brought the `====` along with it. When writing the invariant, I happened to put it in the "space" between that delimiter and the one generated for me like so:

```
\* END TRANSLATION
====

MoneyInvariant == alice_account + bob_account = account_total

=============================================================================
```

This led to some confusion as to why the model checker couldn't find the invariant, when it was so clearly right _there_. Worse, googling the error didn't help (the third or fourth result was the tool code itself).

All of that is to say that I would have found a more specific pointer helpful in tracking down this particular error! I submit one such attempt here for your consideration, in case someone else might also find it useful.