### PR TITLE
Fix typo in about-this-guide

### DIFF
--- a/content/introduction/about-this-guide.md
+++ b/content/introduction/about-this-guide.md
@@ -3,7 +3,7 @@ title = "About This Guide"
 weight = 3
 +++
 
-This guide focuses on the bare minimum required to get you up and running as fast as possible as well as some intermediate techniques to improve your models. This approach will ignore or skim over the vast majority of TLA+ in order to make that small chunk easier to learn. This doesn't mean the other parts boring, difficult, or useless. Far from it. But they're outside the scope of this guide.
+This guide focuses on the bare minimum required to get you up and running as fast as possible as well as some intermediate techniques to improve your models. This approach will ignore or skim over the vast majority of TLA+ in order to make that small chunk easier to learn. This doesn't mean the other parts are boring, difficult, or useless. Far from it. But they're outside the scope of this guide.
 
 I'm assuming you have the following background:
 


### PR DESCRIPTION
First paragraph was missing the word "are" (`the other parts boring` -> `the other parts are boring`)