### PR TITLE
fix `money = 1` typo in introduction example

### DIFF
--- a/content/introduction/example/_index.md
+++ b/content/introduction/example/_index.md
@@ -80,7 +80,7 @@ Can you transfer a negative amount of money? We could add an `assert money > 0` 
 
 A few things should leap out here. First, this isn't part of the PlusCal algorithm. It's pure TLA+ that we put in the bottom of the file so as to be able to reference the transpiled TLA+. TLA+ can reference anything that your PlusCal can, as long as it comes after the `END TRANSLATION` marker. Second, it doesn't change anything. Instead, it's a property of the system. If money is negative, MoneyNotNegative is false. Otherwise, it's true. Properties are specified with `==`.
 
-How is this different from `assert`? Assert checks in one place. We can specify MoneyNotNegative as an _Invariant_ of the system, something that must be true in all possible system states. It becomes part of the model, and then it'll check before money is pulled from Alice's account, being the deposit and the withdrawal, etc. If we added a `money := money - 2` step anywhere the MoneyNotNegative invariant will catch that the spec fails when `money = 1`.
+How is this different from `assert`? Assert checks in one place. We can specify MoneyNotNegative as an _Invariant_ of the system, something that must be true in all possible system states. It becomes part of the model, and then it'll check before money is pulled from Alice's account, being the deposit and the withdrawal, etc. If we added a `money := money - 2` step anywhere the MoneyNotNegative invariant will catch that the spec fails when `money = -1`.
 
 {{% notice note %}}
 *If the model complains that MoneyInvariant is an unknown operator, you may have put the definition after the close of the module. Remember, everything after the first line beginning with `====` is ignored!*


### PR DESCRIPTION
Hi,

In this section of https://www.learntla.com/introduction/example/ page, it should be `money = -1`, I think.

![image](https://user-images.githubusercontent.com/20070310/88042560-ec9ff080-cb6d-11ea-826c-df41eabbddef.png)

This is my first ever pull request on GitHub so pardon my mistakes.