### PR TITLE
fix(tla/logic): escape underscores

### DIFF
--- a/content/tla/logic.md
+++ b/content/tla/logic.md
@@ -44,12 +44,12 @@ Given a set and an operator, determine whether the operator is commutative over 
 
 {{% ans abelian %}}
 ```tla
-IsCommutative(Op(_,_), S) == \A x \in S :
+IsCommutative(Op(\_,\_), S) == \A x \in S :
                           \A y \in S : Op(x,y) = Op(y,x)
 ```
 Alternatively, we could put them on the same line:
 ```tla
-IsCommutative(Op(_,_), S) == \A x \in S, y \in S : Op(x,y) = Op(y,x)
+IsCommutative(Op(\_,\_), S) == \A x \in S, y \in S : Op(x,y) = Op(y,x)
 ```
 {{% /ans %}}
 {{%/q %}}


### PR DESCRIPTION
I think this is needed, as currently, it's rendered as shown:

![image](https://user-images.githubusercontent.com/2630900/121805560-0a75b880-cc4c-11eb-896f-a29d2c0dc697.png)
