### PR TITLE
Addresses issue #88, LargestTwinPair solution

### DIFF
--- a/content/tla/logic.md
+++ b/content/tla/logic.md
@@ -122,7 +122,7 @@ LargestTwinPair(S) == CHOOSE <<x, y>> \in S \X S:
                             /\\ IsPrime(z)
                             /\\ IsPrime(w)
                             /\\ w = z - 2
-                            => z < y
+                            => z <= y
 ```
 {{% /ans %}}
 {{% /q %}}


### PR DESCRIPTION
The largest twin pair is that for which all twin pairs are less than _or equal_ to it. Thanks for writing this book @hwayne!