### PR TITLE
Fix typo in Sets:Mapping example

### DIFF
--- a/content/tla/sets.md
+++ b/content/tla/sets.md
@@ -18,7 +18,7 @@ As always, you can nest filters, and `{x \in {y \in S : P(y)} : Q(x)}` will filt
 
 ### Mapping
 
-`{P(x): x \in S}` applies P to every element in the set. `{ x * x : x \in 1..4 }` is the set `{1, 4, 9, 16}`. `{ x % 2 = 1:x \in 1..8 }` is the set `{TRUE, FALSE}`. 
+`{P(x): x \in S}` applies P to every element in the set. `{ x * x : x \in 1..4 }` is the set `{1, 4, 9, 16}`. `{ x % 2 = 1:x \in 1..8 }` is the set `{TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE}`. 
 
 You can also write `{P(x, y, ...) : x \in S, y \in T, ...}`. `{ x + y : x \in 0..9, y \in { y * 10 : y \in 0..9} }` is the first hundred numbers, in case you wanted to obfuscate `0..99`.
 


### PR DESCRIPTION
Disclaimer: I am learning TLA+ and PlusCal with this great tutorial. But I believe you have a typo here.